### PR TITLE
Corrige escalada de privilegio no cadastro

### DIFF
--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -8,20 +8,18 @@ from services.auth_service import (
     authenticate_user,
     get_current_user,
     register_user,
-    require_role,
 )
 from core import deps
 from core.config import settings
 from core.security import create_access_token
-from models.__all_models import UserRole
 
 
 router = APIRouter(prefix="/auth")
 
 
-@router.post("/register")
+@router.post("/register", response_model=User, status_code=status.HTTP_201_CREATED)
 async def register(user: UserCreate, db: AsyncSession = Depends(deps.get_session)):
-    return await register_user(db, user.username, user.email, user.role, user.password)
+    return await register_user(db, user.username, user.email, user.password)
 
 
 @router.post("/token")

--- a/schemas/user_schema.py
+++ b/schemas/user_schema.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, ConfigDict, EmailStr
 from models.__all_models import UserRole
 import uuid
 
@@ -9,7 +9,11 @@ class UserBase(BaseModel):
     role: UserRole
 
 
-class UserCreate(UserBase):
+class UserCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    username: str
+    email: EmailStr
     password: str
 
 

--- a/services/auth_service.py
+++ b/services/auth_service.py
@@ -28,7 +28,7 @@ async def authenticate_user(db: AsyncSession, email: str, password: str):
 
 
 async def register_user(
-    db: AsyncSession, username: str, email: str, role: UserRole, password: str
+    db: AsyncSession, username: str, email: str, password: str
 ):
     exists_email = await get_user_by_email(db, email)
 
@@ -47,7 +47,9 @@ async def register_user(
         )
 
     hashed_password = get_password_hash(password)
-    return await create_user(db, username, email, role, hashed_password)
+    return await create_user(
+        db, username, email, UserRole.student.value, hashed_password
+    )
 
 
 async def get_current_user(


### PR DESCRIPTION
## O que foi corrigido

Impede que usuários definam o próprio papel no cadastro público.

## Problema

O endpoint `/auth/register` aceitava o campo `role` enviado pelo cliente, permitindo que uma pessoa se cadastrasse como `TEACHER`.

## Correção

- Remove `role` do schema público de cadastro.
- Força novos cadastros públicos como `STUDENT`.
- Rejeita campos extras no payload.
- Define `response_model=User` no endpoint de cadastro.

## Validação

- `python3 -m py_compile schemas/user_schema.py services/auth_service.py routes/auth_routes.py`
- `git diff --check`